### PR TITLE
FIPS integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustls-cng-crypto"
 authors = ["Tom Fay <tom@teamfay.co.uk>"]
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Rustls crypto provider for CNG"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ zeroize = "1.8.1"
 
 [features]
 default = ["tls12"]
+fips = []
 tls12 = ["rustls/tls12"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rustls-cng-crypto
 A [rustls Crypto Provider](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html) for Windows that uses [CNG](https://learn.microsoft.com/en-us/windows/win32/seccng/about-cng) for cryptographic operations.
 
-See the [documentation](https://docs.rs/rustls-cng-crypto) for supported cipher suites and algorithms.
+See the [documentation](https://docs.rs/rustls-cng-crypto) for supported cipher suites and algorithms, along with instructions for running in FIPS mode.
 
 [![crates.io](https://img.shields.io/crates/v/rustls-cng-crypto?style=flat-square&logo=rust)](https://crates.io/crates/rustls-cng-crypto)
 [![Build Status](https://github.com/tofay/rustls-cng-crypto/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tofay/rustls-cng-crypto/actions/workflows/ci.yml?query=branch%3Amain)

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ See the [documentation](https://docs.rs/rustls-cng-crypto) for supported cipher 
 [![Documentation](https://docs.rs/rustls-cng-crypto/badge.svg)](https://docs.rs/rustls-cng-crypto/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Coverage Status (codecov.io)](https://codecov.io/gh/tofay/rustls-cng-crypto/branch/main/graph/badge.svg)](https://codecov.io/gh/tofay/rustls-cng-crypto/)
+
+## Testing
+
+This project tests the crypto provider operations using test vectors from [Project Wycheproof](https://github.com/C2SP/wycheproof) where applicable.

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -1,0 +1,79 @@
+//! # FIPS support
+//!
+//! To use rustls with this crate in FIPS mode, perform the following actions.
+//!
+//! ## 1. Enable FIPS mode for Windows
+//!
+//! See [Microsoft documentation](https://learn.microsoft.com/en-us/windows/security/security-foundations/certification/fips-140-validation).
+//!
+//! ## 2. Enable the `fips` feature, or explicitly use the [crate::fips_provider()] function
+//!
+//! The fips feature changes the behaviour of [crate::default_provider()] to use FIPS-approved cipher suites and key exchange groups.
+//! Or you can explicitly use the [crate::fips_provider()] function to create a provider with FIPS-approved cipher suites and key exchange groups.
+//! If Windows is not running in FIPS mode, the provider will be empty.
+//!
+//! ## 3. Specify `require_ems` when constructing [rustls::ClientConfig] or [rustls::ServerConfig]
+//!
+//! See [rustls documentation](https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#structfield.require_ems) for rationale.
+//!
+//! ## 4. Validate the FIPS status of your ClientConfig or ServerConfig at runtime
+//! See [rustls documentation on FIPS](https://docs.rs/rustls/latest/rustls/manual/_06_fips/index.html#3-validate-the-fips-status-of-your-clientconfigserverconfig-at-run-time).
+
+use rustls::crypto::CryptoProvider;
+use windows::Win32::Security::Cryptography::BCryptGetFipsAlgorithmMode;
+
+use crate::{KeyProvider, SecureRandom, ALL_CIPHER_SUITES, ALL_KX_GROUPS, SUPPORTED_SIG_ALGS};
+
+pub(crate) fn enabled() -> bool {
+    let mut enabled = 0u8;
+    unsafe {
+        BCryptGetFipsAlgorithmMode(&mut enabled).ok().unwrap();
+    }
+    enabled != 0
+}
+
+/// Returns a CNG-based [`CryptoProvider`] using FIPS-approved cipher suites and key exchange groups.
+///
+/// Usage requires that Windows is running in FIPS mode, otherwise the provider will be empty.
+pub fn provider() -> CryptoProvider {
+    CryptoProvider {
+        cipher_suites: ALL_CIPHER_SUITES
+            .iter()
+            .filter(|cs| cs.fips())
+            .cloned()
+            .collect(),
+        kx_groups: ALL_KX_GROUPS
+            .iter()
+            .filter(|kx| kx.fips())
+            .cloned()
+            .collect(),
+        signature_verification_algorithms: SUPPORTED_SIG_ALGS,
+        secure_random: &SecureRandom,
+        key_provider: &KeyProvider,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn fips() {
+        let provider = provider();
+        assert_eq!(provider.fips(), enabled());
+    }
+
+    #[cfg(feature = "fips")]
+    #[test]
+    fn fips_provider_has_fips_cipher_suites() {
+        let provider = provider();
+        assert!(!provider.cipher_suites.is_empty());
+        assert!(!provider.kx_groups.is_empty());
+        assert!(provider.fips());
+        assert!(provider.cipher_suites.iter().any(|cs| cs.tls13().is_some()));
+        #[cfg(feature = "tls12")]
+        assert!(provider.cipher_suites.iter().any(|cs| cs.tls13().is_none()));
+        dbg!(provider);
+    }
+}

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -104,6 +104,10 @@ impl<const SIZE: usize> rustls::crypto::hash::Hash for Algorithm<SIZE> {
     fn algorithm(&self) -> rustls::crypto::hash::HashAlgorithm {
         self.rustls_algorithm
     }
+
+    fn fips(&self) -> bool {
+        crate::fips::enabled()
+    }
 }
 
 impl<const SIZE: usize> rustls::crypto::hash::Context for Context<SIZE> {

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -111,6 +111,10 @@ impl<const HASH_SIZE: usize> RustlsHkdf for Hkdf<HASH_SIZE> {
     fn hmac_sign(&self, key: &OkmBlock, message: &[u8]) -> Tag {
         self.0.with_key(key.as_ref()).sign(&[message])
     }
+
+    fn fips(&self) -> bool {
+        crate::fips::enabled()
+    }
 }
 
 // required for passing null pointer when setting HDKF_PRK_AND_FINALIZE

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -22,6 +22,10 @@ impl<const SIZE: usize> rustls::crypto::hmac::Hmac for Algorithm<SIZE> {
     fn hash_output_len(&self) -> usize {
         SIZE
     }
+
+    fn fips(&self) -> bool {
+        crate::fips::enabled()
+    }
 }
 
 impl<const SIZE: usize> Key for Context<SIZE> {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,5 +1,4 @@
 //! Import keys to CNG
-
 use pkcs1::{RsaPrivateKey, RsaPublicKey};
 use rustls::Error;
 use windows::{

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -146,6 +146,13 @@ impl SupportedKxGroup for KxGroup {
     fn name(&self) -> NamedGroup {
         self.named_group()
     }
+
+    fn fips(&self) -> bool {
+        match self {
+            Self::SECP256R1 | Self::SECP384R1 => crate::fips::enabled(),
+            Self::X25519 => false,
+        }
+    }
 }
 
 impl ActiveKeyExchange for EcKeyExchange {

--- a/src/prf.rs
+++ b/src/prf.rs
@@ -65,6 +65,10 @@ impl<const HASH_SIZE: usize> rustls::crypto::tls12::Prf for Prf<HASH_SIZE> {
                 .unwrap();
         };
     }
+
+    fn fips(&self) -> bool {
+        crate::fips::enabled()
+    }
 }
 
 // Test prf using test vectors from https://mailarchive.ietf.org/arch/msg/tls/fzVCzk-z3FShgGJ6DOXqM1ydxms/

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -86,6 +86,10 @@ impl quic::Algorithm for KeyBuilder {
     fn aead_key_len(&self) -> usize {
         self.packet_algo.key_size()
     }
+
+    fn fips(&self) -> bool {
+        crate::fips::enabled()
+    }
 }
 
 impl quic::PacketKey for PacketKey {

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -19,6 +19,10 @@ impl rustls::crypto::KeyProvider for KeyProvider {
     ) -> Result<Arc<dyn SigningKey>, Error> {
         any_supported_type(&key_der)
     }
+
+    fn fips(&self) -> bool {
+        crate::fips::enabled()
+    }
 }
 
 fn any_supported_type(der: &PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, Error> {

--- a/src/tls12.rs
+++ b/src/tls12.rs
@@ -213,6 +213,10 @@ impl Tls12AeadAlgorithm for aead::Algorithm {
             _ => Err(UnsupportedOperationError),
         }
     }
+
+    fn fips(&self) -> bool {
+        self.is_aes() && crate::fips::enabled()
+    }
 }
 
 impl MessageEncrypter for AesGcmEncrypter {

--- a/src/tls13.rs
+++ b/src/tls13.rs
@@ -105,6 +105,10 @@ impl Tls13AeadAlgorithm for aead::Algorithm {
             _ => return Err(UnsupportedOperationError),
         })
     }
+
+    fn fips(&self) -> bool {
+        self.is_aes() && crate::fips::enabled()
+    }
 }
 
 impl MessageEncrypter for Tls13Crypter {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -322,6 +322,10 @@ impl<const HASH_SIZE: usize> SignatureVerificationAlgorithm for VerificationAlgo
             }
         }
     }
+
+    fn fips(&self) -> bool {
+        crate::fips::enabled()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Make it easy to build crypto provider that only uses FIPS approved algorithms, and make [https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.fips](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.fips) report FIPS status.